### PR TITLE
Removed 'Become A Speaker' button from index page and speakers page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,7 @@ eventDate: "7th - 8th October, 2017"
 typeoutTextValues: '""'
 typeoutFallback: ""
 heroButtons:
- - {link: "https://pyconfhyd.talkfunnel.com/2017/", text: "Become a Speaker"}
+# - {link: "https://pyconfhyd.talkfunnel.com/2017/", text: "Become a Speaker"}
  - {permalink: "/#tickets", text: "Buy tickets"}
 
 # About Block

--- a/_includes/speakers-list.html
+++ b/_includes/speakers-list.html
@@ -50,7 +50,7 @@
                 </div>
                 {% endfor %}
             </div> 
-            <a href="{{ site.c4pUrl }}" class="btn btn-primary waves-effect waves-button waves-light waves-float" target="_blank">Become a speaker</a>     
+            <!-- <a href="{{ site.c4pUrl }}" class="btn btn-primary waves-effect waves-button waves-light waves-float" target="_blank">Become a speaker</a> -->
         </div>
     </div>
 </section>


### PR DESCRIPTION
Removed 'Become A Speaker' button from index page and speakers page as currently we are not accepting proposals for the conference.